### PR TITLE
feat: Add multi-playlist management

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,4 +1,4 @@
-name: "Build legacy Nix package on Ubuntu"
+name: "Build mplayer-server via Nix"
 
 on:
   push:
@@ -10,4 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
       - name: Building package
-        run: nix-build . -A defaultPackage.x86_64-linux
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix --extra-experimental-features "nix-command flake" build --impure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,24 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,30 +263,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "cc"
-version = "1.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
-dependencies = [
- "jobserver",
- "libc",
- "shlex",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -317,23 +279,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "claxon"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "combine"
@@ -355,39 +300,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
-dependencies = [
- "bindgen",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -396,7 +328,11 @@ dependencies = [
  "mach2",
  "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -448,6 +384,16 @@ name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+]
 
 [[package]]
 name = "either"
@@ -594,12 +540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
-
-[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,15 +565,6 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -671,15 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,31 +612,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lewton"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -801,12 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.9.0",
  "jni-sys",
@@ -866,9 +755,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -884,16 +773,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -999,44 +878,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ogg"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1275,14 +1194,12 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
-source = "git+https://github.com/RustAudio/rodio.git?branch=master#ca07a445082bc6effed3b49382efb44062259691"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40ecf59e742e03336be6a3d53755e789fd05a059fa22dfa0ed624722319e183"
 dependencies = [
- "claxon",
  "cpal",
  "dasp_sample",
- "hound",
- "lewton",
  "num-rational",
  "symphonia",
 ]
@@ -1292,12 +1209,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1414,12 +1325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "symphonia"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,10 +1375,13 @@ dependencies = [
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
  "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
+ "symphonia-format-caf",
  "symphonia-format-isomp4",
+ "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
  "symphonia-metadata",
@@ -1519,6 +1433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-codec-alac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8a6666649a08412906476a8b0efd9b9733e241180189e9f92b09c08d0e38f3"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "symphonia-codec-pcm"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,12 +1477,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-caf"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43c99c696a388295a29fe71b133079f5d8b18041cf734c5459c35ad9097af50"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-format-isomp4"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844"
 dependencies = [
  "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb43471a100f7882dc9937395bd5ebee8329298e766250b15b3875652fe3d6f"
+dependencies = [
+ "lazy_static",
  "log",
  "symphonia-core",
  "symphonia-metadata",
@@ -1664,21 +1612,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1988,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +1963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,11 +1995,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2067,6 +2032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2048,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2091,10 +2068,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2109,6 +2098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2114,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2133,6 +2134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2150,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -2164,8 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.7.1"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2188,7 +2202,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -2197,8 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.7.1"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2212,9 +2227,11 @@ dependencies = [
 [[package]]
 name = "zbus_names"
 version = "4.2.0"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
+ "static_assertions",
  "winnow",
  "zvariant",
 ]
@@ -2241,8 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.5.3"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
 dependencies = [
  "endi",
  "enumflags2",
@@ -2254,8 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.3"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2266,8 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.0"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,13 +828,15 @@ dependencies = [
 
 [[package]]
 name = "mplayer-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lofty",
+ "nucleo",
  "rand",
  "regex",
  "rodio",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
  "tracing",
@@ -877,6 +904,27 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1168,6 +1216,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1370,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1731,6 +1817,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,18 @@ description = "Simple dbus server to play music"
 keywords = ["music", "server", "mplayer-server", "mplayer-client", "linux", "dbus", "zbus", "audio", "playback", "mplayer"]
 
 [dependencies]
-zbus = { git = "https://github.com/dbus2/zbus", branch = "main", features = ["tokio"] }
+zbus = { version = "5.11.0", features = ["tokio"] }
 serde = { version = "1.0.204", features = ["serde_derive"] }
 lofty = "0.21.0"
 regex = "1.11.0"
 toml = "0.8.19"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-rodio = { git = "https://github.com/RustAudio/rodio.git", branch = "master", features = ["symphonia-all"]}
 tokio = { version = "1.43.0", features = ["full"] }
 rand = "0.9.0"
 nucleo = "0.5.0"
 serde_json = "1.0.141"
+rodio = { version = "0.21.1", features = ["symphonia-all"] }
 
 [features]
 full-log = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ tracing-subscriber = "0.3.19"
 rodio = { git = "https://github.com/RustAudio/rodio.git", branch = "master", features = ["symphonia-all"]}
 tokio = { version = "1.43.0", features = ["full"] }
 rand = "0.9.0"
+nucleo = "0.5.0"
+serde_json = "1.0.141"
 
 [features]
 full-log = []

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,3 +3,4 @@ sort = "ByDurationDescending" # ByTitleAscending, ByTitleDescending, ByDurationA
 repeat = "AllMusics" # Dont, ThisMusic
 volume = 0.9 # value beteen 0.0 and 1.0
 allow_formats = ["ogg", "flac", "mp3"] # webm, still not supported tho
+playlist_save_path = "/home/user/.local/share/mplayer-server/playlist.json" # No default, provide an empty file

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,14 @@
         };
       in
       {
-        defaultPackage = naersk-lib.buildPackage ./.;
+        defaultPackage = naersk-lib.buildPackage {
+          name = "mplayer-server";
+          src = ./.;
+          buildInputs = with pkgs; [
+            pkg-config
+            alsa-lib
+          ];
+        };
         devShell =
           with pkgs;
           mkShell {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,9 @@
 // TODO: add tests for sorting and stuff
 // TODO: support connection over over http
 // TODO: handle the unwrap calls (this is a mess)
+// TODO: make main playlist name modifiable ("default")
+// TODO: fix bug when you press play on an empty playlist it craches
+// TODO: write a fuzz testing script
 use lofty::{
     self,
     file::{AudioFile, TaggedFileExt},
@@ -10,9 +13,9 @@ use lofty::{
 use rand::seq::SliceRandom;
 use regex::Regex;
 use rodio::Sink;
-use serde::{ser::Serializer, Deserializer};
+use serde::{ser::Serializer, Deserialize, Deserializer, Serialize};
 use std::{
-    borrow::Cow, error::Error, fmt::Display, io::BufReader, path::PathBuf, str::FromStr,
+    borrow::Cow, collections::HashMap, error::Error, fmt::Display, path::PathBuf, str::FromStr,
     time::Duration,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -20,7 +23,7 @@ use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
 use zbus::{connection, interface, object_server::SignalEmitter, zvariant::FilePath, Connection};
 
-use crate::{instrument, light_client::LightClientProxy};
+use crate::{instrument, light_client::LightClientProxy, utils::log};
 
 #[derive(
     PartialEq,
@@ -117,6 +120,16 @@ enum PlayAction {
     GetPlayerStatus,
     ReloadConfig(Config),
     ToggleMute,
+    AddToPlaylist(usize, String, String),
+    DeleteFromPlaylist(usize, String),
+    LoadPlaylist(String),
+    DeletePlaylist(String),
+    CreatePlaylist(String),
+    GetPlaylists,
+    GetPlaylistName,
+    Play,
+    RenamePlaylist(String, String),
+    RemovePlaylist(String),
 }
 
 #[derive(
@@ -559,8 +572,17 @@ impl Default for Metadata {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize, zbus::zvariant::Type)]
+pub enum PlaylistOpperation {
+    AddedMusic,
+    DeletedMusic,
+    PlaylistRenamed,
+    PlaylistRemoved,
+}
+
 #[derive(Clone, Debug)]
 enum Response {
+    PlaylistName(String),
     Timer((f32, f32)),
     Music(Music),
     Playlist(Playlist),
@@ -575,20 +597,21 @@ enum Response {
     NextMusic(Music),
     PlayingStatus(PlayingStatus),
     PlayerStatus(PlayerStatus),
+    Playlists(HashMap<String, Playlist>),
 }
 
 struct Player {
     // controller: awedio::backends::CpalBackend,
     sender: UnboundedSender<PlayAction>,
-    playlist: Playlist,
+    // playlist: Playlist,
     response_reciver: UnboundedReceiver<Response>,
 }
 
+// methods
 #[interface(name = "org.zbus.mplayerServer")]
 impl<'a> Player {
     async fn reload_config(&mut self, #[zbus(signal_emitter)] emitter: SignalEmitter<'_>) {
         let config = Config::try_from_env().unwrap_or_default();
-        self.playlist.reload_from_config(&config);
         // ---------------------------------------------------------------
         self.sender.send(PlayAction::ReloadConfig(config)).unwrap();
         self.config_reloaded(emitter).await.unwrap();
@@ -601,6 +624,29 @@ impl<'a> Player {
     #[zbus(signal)]
     #[allow(unused)]
     async fn config_reloaded(&self, emitter: SignalEmitter<'_>) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlists_updated(
+        &self,
+        emitter: SignalEmitter<'_>,
+        opperatioin: PlaylistOpperation,
+        id: &str,
+    ) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_loaded(&self, emitter: &SignalEmitter<'_>, id: &str) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_deleted(&mut self, emitter: &SignalEmitter<'_>, id: &str)
+        -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_created(&mut self, emitter: &SignalEmitter<'_>, id: &str)
+        -> zbus::Result<()>;
 
     async fn volume(
         &mut self,
@@ -662,7 +708,7 @@ impl<'a> Player {
         .await
         .unwrap_or_default()
     }
-  
+
     async fn get_repeat(&mut self) -> Repeat {
         info!("Requesting repeat status status");
         self.sender.send(PlayAction::GetRepeat).unwrap();
@@ -907,9 +953,9 @@ impl<'a> Player {
     }
 
     async fn play(&mut self, #[zbus(signal_emitter)] emitter: SignalEmitter<'_>) -> RunStatus {
-        let index = self.playlist.playing_index;
-        info!("Playing from index: {index}");
-        self.sender.send(PlayAction::PlayFromIndex(index)).unwrap();
+        // let index = self.playlist.playing_index;
+        // info!("Playing from index: {index}");
+        self.sender.send(PlayAction::Play).unwrap();
         self.resumed(emitter).await.unwrap();
         RunStatus::ok()
     }
@@ -1094,6 +1140,178 @@ impl<'a> Player {
         .unwrap_or_default()
         .to_owned()
     }
+
+    async fn remove_playlist(
+        &mut self,
+        name: String,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> RunStatus {
+        self.sender
+            .send(PlayAction::RemovePlaylist(name.clone()))
+            .unwrap();
+
+        self.playlists_updated(emitter, PlaylistOpperation::PlaylistRemoved, &name)
+            .await
+            .unwrap();
+
+        RunStatus::ok()
+    }
+
+    async fn rename_playlist(
+        &mut self,
+        old: String,
+        new: String,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> RunStatus {
+        self.sender
+            .send(PlayAction::RenamePlaylist(old.clone(), new))
+            .unwrap();
+
+        self.playlists_updated(emitter, PlaylistOpperation::PlaylistRenamed, &old)
+            .await
+            .unwrap();
+
+        RunStatus::ok()
+    }
+
+    // TODO: rename this to `update_playlist`
+    async fn save_to_playlist(
+        &mut self,
+        index: usize,
+        source: String,
+        destination: String,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> RunStatus {
+        // this is an action to the player thread to be as close as possible
+        // to the playing song(s) in case the current self.musics and the "real"
+        // playlist are out of sinc somehow.
+        self.sender
+            .send(PlayAction::AddToPlaylist(
+                index,
+                source,
+                destination.clone(),
+            ))
+            .unwrap();
+
+        self.playlists_updated(emitter, PlaylistOpperation::AddedMusic, &destination)
+            .await
+            .unwrap();
+        RunStatus::ok()
+    }
+
+    async fn delete_from_playlist(
+        &mut self,
+        index: usize,
+        id: String,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) {
+        // this is an action to the player thread to be as close as possible
+        // to the playing song(s) in case the current self.musics and the "real"
+        // playlist are out of sinc somehow.
+        self.sender
+            .send(PlayAction::DeleteFromPlaylist(index, id.clone()))
+            .unwrap();
+
+        self.playlists_updated(emitter, PlaylistOpperation::DeletedMusic, &id)
+            .await
+            .unwrap();
+    }
+
+    async fn delete_playlist(
+        &mut self,
+        id: String,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) {
+        // this is an action to the player thread to be as close as possible
+        // to the playing song(s) in case the current self.musics and the "real"
+        // playlist are out of sinc somehow.
+        self.sender
+            .send(PlayAction::DeletePlaylist(id.clone()))
+            .unwrap();
+        self.playlist_deleted(&emitter, &id).await.unwrap();
+    }
+
+    async fn use_playlist(
+        &mut self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        id: String,
+    ) {
+        self.sender
+            .send(PlayAction::LoadPlaylist(id.clone()))
+            .unwrap();
+        self.sender.send(PlayAction::Stop).unwrap();
+        self.playlist_loaded(&emitter, id.as_str()).await.unwrap();
+    }
+
+    async fn create_playlist(
+        &mut self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        id: String,
+    ) {
+        self.sender
+            .send(PlayAction::CreatePlaylist(id.clone()))
+            .unwrap();
+        self.playlist_created(&emitter, id.as_str()).await.unwrap();
+    }
+
+    async fn get_playlists_names(&mut self) -> Vec<String> {
+        let mut playlist = self
+            .get_playlists()
+            .await
+            .keys()
+            .map(|v| v.to_owned())
+            .collect::<Vec<String>>();
+        playlist.sort();
+        playlist
+    }
+
+    async fn get_playlist_name(&mut self) -> String {
+        self.sender.send(PlayAction::GetPlaylistName).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(20), async {
+            match self.response_reciver.recv().await {
+                Some(data) => match data {
+                    Response::PlaylistName(name) => return name,
+                    _ => {
+                        error!("Got unexpected response");
+                        #[cfg(feature = "full-log")]
+                        error!(response=?data);
+                        return String::new();
+                    }
+                },
+                None => {
+                    return String::new();
+                }
+            }
+        })
+        .await
+        .unwrap_or_default()
+        .to_owned()
+    }
+
+    async fn get_playlists(&mut self) -> HashMap<String, Playlist> {
+        self.sender.send(PlayAction::GetPlaylists).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(20), async {
+            match self.response_reciver.recv().await {
+                Some(data) => match data {
+                    Response::Playlists(playlists) => return playlists,
+                    _ => {
+                        error!("Got unexpected response");
+                        #[cfg(feature = "full-log")]
+                        error!(response=?data);
+                        return HashMap::new();
+                    }
+                },
+                None => {
+                    return HashMap::new();
+                }
+            }
+        })
+        .await
+        .unwrap_or_default()
+        .to_owned()
+    }
 }
 
 pub struct Server {
@@ -1132,6 +1350,7 @@ impl Server {
     /// screates a new server and connect it to the specified
     /// dbus address
     pub async fn new(dbus_addr: String) -> Self {
+        // init
         let config = Config::read_config(PathBuf::new()).unwrap_or_default();
         let playlist = Playlist::from_config(&config);
 
@@ -1152,7 +1371,7 @@ impl Server {
             player: Player {
                 response_reciver,
                 sender,
-                playlist,
+                // playlist,
             },
         }
     }
@@ -1178,7 +1397,7 @@ impl Server {
             player: Player {
                 response_reciver,
                 sender,
-                playlist,
+                // playlist,
             },
         }
     }
@@ -1243,6 +1462,7 @@ struct Playlist {
     sort: Sort,
     repeat: Repeat,
     playing_index: u32,
+    name: String,
 }
 
 macro_rules! ternary {
@@ -1251,6 +1471,12 @@ macro_rules! ternary {
             $v
         }
     };
+}
+
+#[derive(Deserialize, Serialize)]
+struct PlaylistEntry {
+    key: String,
+    value: Vec<Music>,
 }
 
 // TODO: check if playlist is already sorted by the element requested, if so, don't resort
@@ -1266,7 +1492,7 @@ impl Playlist {
         self.sort = sort;
     }
 
-    #[instrument(name = "asafadsdf", skip_all)]
+    #[instrument(skip_all)]
     fn visit_dirs(path: &PathBuf, _cfg: &Config) -> Self {
         let mut musics = vec![];
         if path.is_dir() {
@@ -1309,12 +1535,17 @@ impl Playlist {
             playing_index: u32::default(),
             sort: Sort::default(),
             repeat: Repeat::default(),
+            name: String::default(),
         }
     }
 
     fn from_config(cfg: &Config) -> Self {
         let mut playlist = Self::visit_dirs(&PathBuf::from_str(&cfg.path).unwrap(), cfg);
         playlist.sort(cfg.sort);
+        playlist.name = String::from("default");
+        playlist
+            .save(&PathBuf::from_str(&cfg.playlist_save_path).unwrap())
+            .unwrap();
         playlist
     }
 
@@ -1378,6 +1609,19 @@ impl Playlist {
             }
         }
     }
+
+    fn save(&mut self, path: &PathBuf) -> std::io::Result<()> {
+        let content = std::fs::read_to_string(path).unwrap();
+        let mut map = serde_json::from_str::<HashMap<&str, Playlist>>(&content).unwrap_or_default();
+        map.insert(&self.name, self.to_owned());
+
+        std::fs::write(path, serde_json::to_string_pretty(&map).unwrap()).unwrap();
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -1416,6 +1660,7 @@ struct Config {
     repeat: Repeat,
     volume: f32,
     allow_formats: Option<Vec<FileFormat>>,
+    playlist_save_path: String,
 }
 
 impl Default for Config {
@@ -1426,6 +1671,8 @@ impl Default for Config {
             repeat: Repeat::default(),
             volume: 0.5,
             allow_formats: Some(vec![FileFormat::Ogg, FileFormat::Flac, FileFormat::Mp3]),
+            // FIXME
+            playlist_save_path: String::default(),
         }
     }
 }
@@ -1515,6 +1762,7 @@ struct AudioThread {
     action_reciver: UnboundedReceiver<PlayAction>,
     data_sender: UnboundedSender<Response>,
     extra: Extra,
+    playlist_save_path: String,
 }
 
 unsafe impl std::marker::Send for AudioThread {}
@@ -1530,6 +1778,7 @@ impl AudioThread {
         let sink = rodio::Sink::connect_new(&stream_handle.mixer());
         sink.set_volume(config.volume);
         let extra = Extra::default().muted_volume(config.volume);
+        let playlist_save_path = config.playlist_save_path.clone();
         let playlist = Playlist::from_config(&config);
         Self {
             action_sender,
@@ -1537,6 +1786,7 @@ impl AudioThread {
             stream_handle,
             sink,
             playlist,
+            playlist_save_path,
             data_sender,
             extra,
         }
@@ -1548,274 +1798,521 @@ impl AudioThread {
         });
     }
 
+    pub async fn remove_playlist(&mut self, name: String) -> std::io::Result<()> {
+        if name.eq("default") {
+            return Err(std::io::Error::other(
+                "You can't remove the 'default' playlist",
+            ));
+        }
+
+        let content = std::fs::read_to_string(self.playlist_save_path.as_str())?;
+        let mut map: HashMap<&str, Playlist> = serde_json::from_str(&content)?;
+        let mut playlist = match self.get_playlist(name.clone()).await {
+            Some(music) => music,
+            None => {
+                error!(playlist_name=? name,"Playlist does not exist");
+                return Ok(());
+            }
+        };
+        playlist.name = name.clone();
+
+        map.remove(name.as_str()).unwrap();
+
+        std::fs::write(
+            self.playlist_save_path.as_str(),
+            serde_json::to_string_pretty(&map)?,
+        )?;
+        Ok(())
+    }
+
+    pub async fn rename_playlist(&mut self, old: String, new: String) -> std::io::Result<()> {
+        if old.eq("default") {
+            return Err(std::io::Error::other(
+                "You can't rename the 'default' playlist",
+            ));
+        }
+        let content = std::fs::read_to_string(self.playlist_save_path.as_str())?;
+        let mut map: HashMap<&str, Playlist> = serde_json::from_str(&content)?;
+        let mut playlist = match self.get_playlist(old.clone()).await {
+            Some(music) => music,
+            None => {
+                error!(playlist_name=? old,"Playlist does not exist");
+                return Ok(());
+            }
+        };
+        playlist.name = new.clone();
+
+        map.remove(old.as_str()).unwrap();
+        map.insert(&new, playlist);
+
+        std::fs::write(
+            self.playlist_save_path.as_str(),
+            serde_json::to_string_pretty(&map)?,
+        )?;
+
+        Ok(())
+    }
+
+    pub async fn play_from_index(&mut self, index: u32) {
+        // TODO: what if this fail
+        // FIXME
+        self.playlist.playing_index = index;
+        let music = self.playlist.musics.get(index as usize).unwrap();
+
+        info!("playing music : {}", music);
+        self.sink.clear();
+        self.sink.append(
+            rodio::Decoder::try_from(
+                std::fs::File::open(PathBuf::from(music.path.clone())).unwrap(),
+            )
+            .unwrap(),
+        );
+        let thing = self.action_sender.clone();
+        self.sink
+            .append(rodio::source::EmptyCallback::new(Box::new(move || {
+                thing.send(PlayAction::Ended).unwrap();
+            })));
+        self.sink.play();
+    }
+
+    // TODO: Make this method return an Result then log the error outside
+    #[allow(unreachable_code)]
+    #[instrument(name = "AudioThread", skip_all)]
+    pub async fn handle_action(&mut self, action: PlayAction) -> std::io::Result<()> {
+        match action {
+            PlayAction::PlayFromIndex(index) => {
+                self.play_from_index(index).await;
+            }
+            PlayAction::TogglePlay => {
+                if self.sink.is_paused() {
+                    self.sink.play();
+                } else {
+                    self.sink.pause();
+                }
+            }
+            PlayAction::Ended => match self.playlist.repeat {
+                // NOTE: using rt because we hit a `no reactor running` error
+                // NOTE: using light client because we want to send signals for
+                // the new playing music
+                Repeat::SameMusic => {
+                    let index = self.playlist.playing_index;
+                    let conn = Connection::session().await.unwrap_or_else(|_| {
+                        panic!("Could not connect to the bus address, aborting...");
+                    });
+                    let proxy = LightClientProxy::new(&conn).await.unwrap();
+                    proxy.play_from_index(index).await.unwrap();
+                    conn.close().await.unwrap();
+                }
+                Repeat::AllMusics => {
+                    let conn = Connection::session().await.unwrap_or_else(|_| {
+                        panic!("Could not connect to the bus address, aborting...");
+                    });
+                    let proxy = LightClientProxy::new(&conn).await.unwrap();
+                    proxy.play_next().await.unwrap();
+                    conn.close().await.unwrap();
+                    #[cfg(feature = "full-log")]
+                    info!("Playing next music");
+                }
+                Repeat::Dont => {}
+            },
+            PlayAction::Stop => {
+                self.sink.stop();
+            }
+            PlayAction::Quit => {
+                self.sink.stop();
+            }
+            PlayAction::Pause => {
+                self.sink.pause();
+            }
+            PlayAction::Resume => {
+                self.sink.play();
+            }
+            PlayAction::PlayNextMusic => {
+                let next_index = self.playlist.next_music_index();
+                self.action_sender
+                    .send(PlayAction::PlayFromIndex(next_index))
+                    .unwrap();
+            }
+            PlayAction::PlayPreviousMusic => {
+                let previous_index = self.playlist.previous_music_index();
+                self.action_sender
+                    .send(PlayAction::PlayFromIndex(previous_index))
+                    .unwrap();
+            }
+            PlayAction::Seek(duration) => {
+                let duration = Duration::from_secs_f64(duration);
+                self.sink.try_seek(duration).unwrap();
+            }
+            PlayAction::Repeat(repeat) => {
+                info!("Repeat: {repeat:?}");
+                self.playlist.repeat(repeat);
+            }
+            PlayAction::Sort(sort) => {
+                info!("Sort: {sort:?}");
+                self.playlist.sort(sort);
+            }
+            PlayAction::Volume(volume) => {
+                self.sink.set_volume(volume);
+            }
+            PlayAction::GetPlaylist => {
+                #[cfg(feature = "full-log")]
+                info!("Recived playlist request");
+                let playlist = self.playlist.clone();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending playitst to requester");
+                self.data_sender.send(Response::Playlist(playlist)).unwrap();
+            }
+            PlayAction::GetPlaying | PlayAction::GetPlayingMusic => {
+                #[cfg(feature = "full-log")]
+                info!("Recived music info request");
+                let music = self.playlist.playing_music();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending music info to requester");
+                self.data_sender.send(Response::Music(music)).unwrap();
+            }
+            PlayAction::GetPlayingIndex => {
+                #[cfg(feature = "full-log")]
+                info!("Recived playing index request");
+                let index = self.playlist.playing_index;
+
+                #[cfg(feature = "full-log")]
+                info!("Sending playing index requester");
+                self.data_sender
+                    .send(Response::PlayingIndex(index))
+                    .unwrap();
+            }
+            PlayAction::GetRepeat => {
+                #[cfg(feature = "full-log")]
+                info!("Recived repeat state request");
+                let repeat = self.playlist.repeat;
+
+                #[cfg(feature = "full-log")]
+                info!("Sending repeat state requester");
+                self.data_sender.send(Response::Repeat(repeat)).unwrap();
+            }
+            PlayAction::GetSort => {
+                info!("Recived sorting state request");
+                let sort = self.playlist.sort;
+                info!("Sending sorting state requester");
+                self.data_sender.send(Response::Sort(sort)).unwrap();
+            }
+            PlayAction::GetMetadata => {
+                #[cfg(feature = "full-log")]
+                info!("Recived sorting state request");
+                let metadata = self.playlist.playing_music().extract_matadata();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending sorting state requester");
+                self.data_sender.send(Response::Metadata(metadata)).unwrap();
+            }
+            PlayAction::GetLyrics => {
+                #[cfg(feature = "full-log")]
+                info!("Recived Lyrics request");
+                let lyrics = self
+                    .playlist
+                    .playing_music()
+                    .extract_lyrics()
+                    .unwrap_or_default();
+
+                #[cfg(feature = "full-log")]
+                {
+                    info!("Sending lyrics to requester");
+                    info!("{lyrics}");
+                }
+                self.data_sender.send(Response::Lyrics(lyrics)).unwrap();
+            }
+            PlayAction::GetPlayedDuration => {
+                #[cfg(all(feature = "full-log", feature = "trivial"))]
+                info!("Recived played duration request");
+
+                let duration = self.sink.get_pos();
+                #[cfg(all(feature = "full-log", feature = "trivial"))]
+                info!("Sending played duration: {duration:?}");
+                self.data_sender
+                    .send(Response::PlayedDuration(duration))
+                    .unwrap();
+            }
+            PlayAction::GetVolume => {
+                #[cfg(feature = "full-log")]
+                info!("Recived volume info request");
+                let volume = self.sink.volume();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending volume info: {volume:?}");
+                self.data_sender.send(Response::Volume(volume)).unwrap();
+            }
+            PlayAction::GetPreviousMusic => {
+                #[cfg(feature = "full-log")]
+                info!("Recived previous music info request");
+                let music = self.playlist.previous_music().unwrap_or_default();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending previous music info: {music:?}");
+                self.data_sender
+                    .send(Response::PreviousMusic(music))
+                    .unwrap();
+            }
+            PlayAction::GetNextMusic => {
+                #[cfg(feature = "full-log")]
+                info!("Recived next music info request");
+
+                let music = self.playlist.next_music().unwrap_or_default();
+                #[cfg(feature = "full-log")]
+                info!("Sending next music info: {music:?}");
+                self.data_sender.send(Response::NextMusic(music)).unwrap();
+            }
+            PlayAction::GetPlayingStatus => {
+                let paused = self.sink.is_paused();
+                let emtpy = self.sink.empty();
+                if paused && emtpy {
+                    self.data_sender
+                        .send(Response::PlayingStatus(PlayingStatus::Stopped))
+                        .unwrap();
+                } else if paused && !emtpy {
+                    self.data_sender
+                        .send(Response::PlayingStatus(PlayingStatus::Pausing))
+                        .unwrap();
+                } else if !paused && !emtpy {
+                    self.data_sender
+                        .send(Response::PlayingStatus(PlayingStatus::Playing))
+                        .unwrap();
+                }
+            }
+            PlayAction::GetIndex => {
+                #[cfg(feature = "full-log")]
+                info!("Recived playing index request");
+                let index = self.playlist.playing_index;
+
+                #[cfg(feature = "full-log")]
+                info!("Sending playing index: {index}");
+                self.data_sender
+                    .send(Response::PlayingIndex(index))
+                    .unwrap();
+            }
+            PlayAction::GetTimer => {
+                #[cfg(all(feature = "full-log", feature = "trivial"))]
+                info!("Recived timer request");
+                let timer = (
+                    self.sink.get_pos().as_secs_f32(),
+                    self.playlist.playing_music().length.as_secs_f32(),
+                );
+                #[cfg(all(feature = "full-log", feature = "trivial"))]
+                info!("Sending timer info");
+                self.data_sender.send(Response::Timer(timer)).unwrap();
+            }
+            PlayAction::GetPlayerStatus => {
+                // FIXME
+                let music = self.playlist.playing_music();
+                let volume = self.sink.volume();
+                let index = self.playlist.playing_index;
+                let status = self.sink.status();
+                let player_status = PlayerStatus::new(status, music, volume, index);
+                self.data_sender
+                    .send(Response::PlayerStatus(player_status))
+                    .unwrap();
+            }
+            PlayAction::ReloadConfig(config) => {
+                self.playlist.reload_from_config(&config);
+            }
+            PlayAction::ToggleMute => {
+                if self.sink.volume().ne(&0.0) {
+                    self.extra.set_muted_volume(self.sink.volume());
+                    self.sink.set_volume(0.0);
+                } else {
+                    self.sink.set_volume(self.extra.muted_volume);
+                }
+            }
+            // ---------------------
+            PlayAction::AddToPlaylist(index, source, destination) => {
+                return self.add_to_playlist(index, source, destination).await
+            }
+            PlayAction::DeleteFromPlaylist(index, id) => {
+                return self.delete_from_playlist(index, id).await
+            }
+            PlayAction::LoadPlaylist(id) => return self.load_playlist(id).await,
+            PlayAction::DeletePlaylist(id) => return self.delete_playlist(id).await,
+            PlayAction::CreatePlaylist(id) => return self.create_playlist(id).await,
+            PlayAction::GetPlaylists => {
+                #[cfg(feature = "full-log")]
+                info!("Recived playlists request");
+                let playlists = self.get_playlists().await;
+
+                self.data_sender
+                    .send(Response::Playlists(playlists))
+                    .unwrap();
+            }
+            PlayAction::GetPlaylistName => {
+                #[cfg(feature = "full-log")]
+                info!("Recived playlist name request");
+                let name = self.playlist.name();
+
+                #[cfg(feature = "full-log")]
+                info!("Sending playlist name: {name:?}");
+                self.data_sender.send(Response::PlaylistName(name)).unwrap();
+            }
+            PlayAction::Play => {
+                self.play_from_index(self.playlist.playing_index).await;
+            }
+            PlayAction::RenamePlaylist(old, new) => {
+                self.rename_playlist(old, new).await;
+            }
+            PlayAction::RemovePlaylist(name) => {
+                self.remove_playlist(name).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn add_to_playlist(
+        &mut self,
+        index: usize,
+        source: String,
+        destination: String,
+    ) -> std::io::Result<()> {
+        let playlist = match self.get_playlist(source.clone()).await {
+            Some(music) => music,
+            None => {
+                error!(source_playlist=? source,"Playlist does not exist");
+                return Ok(());
+            }
+        };
+
+        match playlist.musics.get(index as usize) {
+            Some(music) => {
+                let content = std::fs::read_to_string(self.playlist_save_path.as_str())?;
+                let mut map: HashMap<&str, Playlist> = serde_json::from_str(&content)?;
+                let list = match map.get(destination.as_str()) {
+                    Some(list) => {
+                        let mut new_list = list.clone();
+                        new_list.musics.push(music.to_owned());
+                        new_list.musics.dedup();
+                        new_list
+                    }
+                    None => Playlist::default(),
+                };
+                map.insert(&destination, list.clone());
+
+                std::fs::write(
+                    self.playlist_save_path.as_str(),
+                    serde_json::to_string_pretty(&map)?,
+                )?;
+
+                if self.playlist.name().eq(&destination) {
+                    self.playlist = list;
+                }
+            }
+            None => error!(
+                destination = destination,
+                source = source,
+                index = index,
+                "Music index is out of bound"
+            ),
+        }
+
+        Ok(())
+    }
+
+    async fn delete_from_playlist(&mut self, index: usize, id: String) -> std::io::Result<()> {
+        let content = std::fs::read_to_string(self.playlist_save_path.as_str())?;
+        let mut map: HashMap<&str, Playlist> = serde_json::from_str(&content)?;
+        match map.get(id.as_str()) {
+            Some(playlist) => {
+                if index > playlist.musics.len() {
+                    error!(
+                        playlist = id,
+                        index = index,
+                        "Can't delete music in playlist, index out of range"
+                    );
+                    return Ok(());
+                }
+                let mut new_list = playlist.clone();
+                new_list.musics.remove(index);
+                map.insert(id.as_str(), new_list);
+
+                std::fs::write(
+                    self.playlist_save_path.as_str(),
+                    serde_json::to_string_pretty(&map).unwrap(),
+                )
+                .unwrap();
+            }
+            None => {
+                error!(playlist = id, "No playlist found");
+            }
+        }
+        Ok(())
+    }
+
+    async fn load_playlist(&mut self, id: String) -> std::io::Result<()> {
+        log(&id, "asdf.log").unwrap();
+        match self.get_playlist(id.clone()).await {
+            Some(playlist) => {
+                self.playlist = playlist;
+                self.playlist.playing_index = 0;
+                Ok(())
+            }
+            None => Err(std::io::Error::other(format!(
+                "Playlist with id {} does not exist",
+                id
+            ))),
+        }
+    }
+
+    async fn get_playlist(&mut self, id: String) -> Option<Playlist> {
+        self.get_playlists().await.get(&id).map(|v| v.to_owned())
+    }
+
+    async fn get_playlists(&mut self) -> HashMap<String, Playlist> {
+        let content = std::fs::read_to_string(self.playlist_save_path.as_str()).unwrap_or_default();
+        let all_playlists: HashMap<String, Playlist> =
+            serde_json::from_str(&content).unwrap_or_default();
+        all_playlists
+    }
+
+    async fn delete_playlist(&mut self, id: String) -> std::io::Result<()> {
+        if id.eq("default") {
+            error!("You can't delete the `default` playlist");
+            return Ok(());
+        }
+        let mut map = self.get_playlists().await;
+        let _ = map.remove(id.as_str());
+
+        std::fs::write(
+            self.playlist_save_path.as_str(),
+            serde_json::to_string_pretty(&map)?,
+        )?;
+        Ok(())
+    }
+
+    async fn create_playlist(&mut self, id: String) -> std::io::Result<()> {
+        let mut playlists = self.get_playlists().await;
+
+        match playlists.get(&id.clone()) {
+            Some(_) => {
+                error!(id=?id,"Can't create a new playlist, playlist already exist");
+                return Ok(());
+            }
+            None => {
+                let mut playlist = Playlist::default();
+                playlist.name = id.clone();
+                let _ = playlists.insert(id, playlist);
+                std::fs::write(
+                    self.playlist_save_path.as_str(),
+                    serde_json::to_string_pretty(&playlists)?,
+                )?;
+                Ok(())
+            }
+        }
+    }
+
     #[allow(unreachable_code)]
     #[instrument(name = "AudioThread", skip_all)]
     pub async fn audio_thread(mut self) {
         loop {
-            if let Some(data) = self.action_reciver.recv().await {
-                match data {
-                    PlayAction::PlayFromIndex(index) => {
-                        // TODO: what if this fail
-                        // FIXME
-                        self.playlist.playing_index = index;
-                        let music = self.playlist.musics.get(index as usize).unwrap();
-
-                        info!("playing music : {}", music);
-                        self.sink.clear();
-                        self.sink.append(
-                            rodio::Decoder::try_from(
-                                std::fs::File::open(PathBuf::from(music.path.clone())).unwrap(),
-                            )
-                            .unwrap(),
-                        );
-                        let thing = self.action_sender.clone();
-                        self.sink
-                            .append(rodio::source::EmptyCallback::new(Box::new(move || {
-                                thing.send(PlayAction::Ended).unwrap();
-                            })));
-                        self.sink.play();
-                    }
-                    PlayAction::TogglePlay => {
-                        if self.sink.is_paused() {
-                            self.sink.play();
-                        } else {
-                            self.sink.pause();
-                        }
-                    }
-                    PlayAction::Ended => match self.playlist.repeat {
-                        // NOTE: using rt because we hit a `no reactor running` error
-                        // NOTE: using light client because we want to send signals for
-                        // the new playing music
-                        Repeat::SameMusic => {
-                            let index = self.playlist.playing_index;
-                            let conn = Connection::session().await.unwrap_or_else(|_| {
-                                panic!("Could not connect to the bus address, aborting...");
-                            });
-                            let proxy = LightClientProxy::new(&conn).await.unwrap();
-                            proxy.play_from_index(index).await.unwrap();
-                            conn.close().await.unwrap();
-                        }
-                        Repeat::AllMusics => {
-                            let conn = Connection::session().await.unwrap_or_else(|_| {
-                                panic!("Could not connect to the bus address, aborting...");
-                            });
-                            let proxy = LightClientProxy::new(&conn).await.unwrap();
-                            proxy.play_next().await.unwrap();
-                            conn.close().await.unwrap();
-                            #[cfg(feature = "full-log")]
-                            info!("Playing next music");
-                        }
-                        Repeat::Dont => {}
-                    },
-                    PlayAction::Stop => {
-                        self.sink.stop();
-                    }
-                    PlayAction::Quit => {
-                        self.sink.stop();
-                    }
-                    PlayAction::Pause => {
-                        self.sink.pause();
-                    }
-                    PlayAction::Resume => {
-                        self.sink.play();
-                    }
-                    PlayAction::PlayNextMusic => {
-                        let next_index = self.playlist.next_music_index();
-                        self.action_sender
-                            .send(PlayAction::PlayFromIndex(next_index))
-                            .unwrap();
-                    }
-                    PlayAction::PlayPreviousMusic => {
-                        let previous_index = self.playlist.previous_music_index();
-                        self.action_sender
-                            .send(PlayAction::PlayFromIndex(previous_index))
-                            .unwrap();
-                    }
-                    PlayAction::Seek(duration) => {
-                        let duration = Duration::from_secs_f64(duration);
-                        self.sink.try_seek(duration).unwrap();
-                    }
-                    PlayAction::Repeat(repeat) => {
-                        info!("Repeat: {repeat:?}");
-                        self.playlist.repeat(repeat);
-                    }
-                    PlayAction::Sort(sort) => {
-                        info!("Sort: {sort:?}");
-                        self.playlist.sort(sort);
-                    }
-                    PlayAction::Volume(volume) => {
-                        self.sink.set_volume(volume);
-                    }
-                    PlayAction::GetPlaylist => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived playlist request");
-                        let playlist = self.playlist.clone();
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending playitst to requester");
-                        self.data_sender.send(Response::Playlist(playlist)).unwrap();
-                    }
-                    PlayAction::GetPlaying | PlayAction::GetPlayingMusic => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived music info request");
-                        let music = self.playlist.playing_music();
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending music info to requester");
-                        self.data_sender.send(Response::Music(music)).unwrap();
-                    }
-                    PlayAction::GetPlayingIndex => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived playing index request");
-                        let index = self.playlist.playing_index;
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending playing index requester");
-                        self.data_sender
-                            .send(Response::PlayingIndex(index))
-                            .unwrap();
-                    }
-                    PlayAction::GetRepeat => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived repeat state request");
-                        let repeat = self.playlist.repeat;
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending repeat state requester");
-                        self.data_sender.send(Response::Repeat(repeat)).unwrap();
-                    }
-                    PlayAction::GetSort => {
-                        info!("Recived sorting state request");
-                        let sort = self.playlist.sort;
-                        info!("Sending sorting state requester");
-                        self.data_sender.send(Response::Sort(sort)).unwrap();
-                    }
-                    PlayAction::GetMetadata => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived sorting state request");
-                        let metadata = self.playlist.playing_music().extract_matadata();
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending sorting state requester");
-                        self.data_sender.send(Response::Metadata(metadata)).unwrap();
-                    }
-                    PlayAction::GetLyrics => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived Lyrics request");
-                        let lyrics = self
-                            .playlist
-                            .playing_music()
-                            .extract_lyrics()
-                            .unwrap_or_default();
-
-                        #[cfg(feature = "full-log")]
-                        {
-                            info!("Sending lyrics to requester");
-                            info!("{lyrics}");
-                        }
-                        self.data_sender.send(Response::Lyrics(lyrics)).unwrap();
-                    }
-                    PlayAction::GetPlayedDuration => {
-                        #[cfg(all(feature = "full-log", feature = "trivial"))]
-                        info!("Recived played duration request");
-
-                        let duration = self.sink.get_pos();
-                        #[cfg(all(feature = "full-log", feature = "trivial"))]
-                        info!("Sending played duration: {duration:?}");
-                        self.data_sender
-                            .send(Response::PlayedDuration(duration))
-                            .unwrap();
-                    }
-                    PlayAction::GetVolume => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived volume info request");
-                        let volume = self.sink.volume();
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending volume info: {volume:?}");
-                        self.data_sender.send(Response::Volume(volume)).unwrap();
-                    }
-                    PlayAction::GetPreviousMusic => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived previous music info request");
-                        let music = self.playlist.previous_music().unwrap_or_default();
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending previous music info: {music:?}");
-                        self.data_sender
-                            .send(Response::PreviousMusic(music))
-                            .unwrap();
-                    }
-                    PlayAction::GetNextMusic => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived next music info request");
-
-                        let music = self.playlist.next_music().unwrap_or_default();
-                        #[cfg(feature = "full-log")]
-                        info!("Sending next music info: {music:?}");
-                        self.data_sender.send(Response::NextMusic(music)).unwrap();
-                    }
-                    PlayAction::GetPlayingStatus => {
-                        let paused = self.sink.is_paused();
-                        let emtpy = self.sink.empty();
-                        if paused && emtpy {
-                            self.data_sender
-                                .send(Response::PlayingStatus(PlayingStatus::Stopped))
-                                .unwrap();
-                        } else if paused && !emtpy {
-                            self.data_sender
-                                .send(Response::PlayingStatus(PlayingStatus::Pausing))
-                                .unwrap();
-                        } else if !paused && !emtpy {
-                            self.data_sender
-                                .send(Response::PlayingStatus(PlayingStatus::Playing))
-                                .unwrap();
-                        }
-                    }
-                    PlayAction::GetIndex => {
-                        #[cfg(feature = "full-log")]
-                        info!("Recived playing index request");
-                        let index = self.playlist.playing_index;
-
-                        #[cfg(feature = "full-log")]
-                        info!("Sending playing index: {index}");
-                        self.data_sender
-                            .send(Response::PlayingIndex(index))
-                            .unwrap();
-                    }
-                    PlayAction::GetTimer => {
-                        #[cfg(all(feature = "full-log", feature = "trivial"))]
-                        info!("Recived timer request");
-                        let timer = (
-                            self.sink.get_pos().as_secs_f32(),
-                            self.playlist.playing_music().length.as_secs_f32(),
-                        );
-                        #[cfg(all(feature = "full-log", feature = "trivial"))]
-                        info!("Sending timer info");
-                        self.data_sender.send(Response::Timer(timer)).unwrap();
-                    }
-                    PlayAction::GetPlayerStatus => {
-                        // FIXME
-                        let music = self.playlist.playing_music();
-                        let volume = self.sink.volume();
-                        let index = self.playlist.playing_index;
-                        let status = self.sink.status();
-                        let player_status = PlayerStatus::new(status, music, volume, index);
-                        self.data_sender
-                            .send(Response::PlayerStatus(player_status))
-                            .unwrap();
-                    }
-                    PlayAction::ReloadConfig(config) => {
-                        self.playlist.reload_from_config(&config);
-                    }
-                    PlayAction::ToggleMute => {
-                        if self.sink.volume().ne(&0.0) {
-                            self.extra.set_muted_volume(self.sink.volume());
-                            self.sink.set_volume(0.0);
-                        } else {
-                            self.sink.set_volume(self.extra.muted_volume);
-                        }
-                    }
+            if let Some(action) = self.action_reciver.recv().await {
+                if let Err(e) = self.handle_action(action).await {
+                    error!(error=?e, "Error");
                 }
             }
         }


### PR DESCRIPTION
Introduces a playlist management system, to create, delete, rename, and switch between multiple playlists.

Changes :
- Save playlists to a JSON file, configured via the `playlist_save_path` option.
- Update D-Bus methods for playlist manipulation (create, delete, rename, add/remove musics, load).
- Implemented new D-Bus signals to notify clients of playlist updates.
- Refactored the audio thread to handle complex playlist operations.
- Added `serde_json` dependency for playlist serialization.
- Use stable release for `zbus` and `rodio` (instead using remote/master).
- Fix flake build/run.
- Fix workflow project wuild with Nix.
